### PR TITLE
Updates for Rust 1.35.0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
-#[deriving(PartialEq)]
-#[deriving(Show)]
+#[derive(PartialEq)]
+#[derive(Debug)]
 pub struct Pair {
     pub key: String,
     pub val: Option<String>,

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -54,6 +54,6 @@ fn it_parses() {
     ], logfmt::parse("y=\\x"));
 
     // this is considered garbage and produces nothing
-    assert_eq!(vec![
-    ], logfmt::parse("=y"));
+    let input: Vec<logfmt::Pair> = vec![];
+    assert_eq!(input, logfmt::parse("=y"));
 }


### PR DESCRIPTION
deriving changed when renamed to derive, update for new names. Also handle a type ambiguity in empty vector.