### PR TITLE
Add License & Metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,3 +3,5 @@
 name = "logfmt"
 version = "0.0.2"
 authors = ["Brandur <brandur@mutelight.org>"]
+license = "MIT"
+description = "logfmt parser for Rust"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Brandur
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # logfmt
 
-logfmt parser in Rust.
+logfmt parser in Rust, forked to facilitate creation of a crate
 
 ``` rust
 logfmt::parse("a=1 b=\"bar\" ƒ=2h3s r=\"esc\t\" d x=sf"));


### PR DESCRIPTION
@brandur, I went to publish the latest version of `angle-grinder` to the crate but discovered I can't without removing the `git` dependency on `logfmt`. I'd like to fork the repo and start maintaining the crate, but to do that, I need to add a license. 

I've added an MIT license, inline with your other repos. Let me know if that works for you.